### PR TITLE
Add multipart downloads with resume capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Minimal Google Drive Downloader Written in Go
 - Database for storing credentials and token
 - Resuming on partially downloaded files
 - Skipping Existing files
+- Multipart Downloads with Custom Number of Parts and Resume Capability
 
 # Documentation
 
@@ -46,3 +47,12 @@ drivedlgo --help
 ## Note:-
 First time run after set command will authorize the credentials and generate token. 
 
+## Multipart Downloads
+
+To enable multipart downloads, use the `--part` flag followed by the number of parts you want to split the download into. For example, to download a file in 8 parts, use the following command:
+
+`
+drivedlgo --part 8 <fileid/link>
+`
+
+The parts implementation is smart and resume capable, similar to IDM. Verification takes place as usual after a successful download.

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func downloadCallback(c *cli.Context) error {
 		cus_path = c.String("path")
 	}
 	log.SetOutput(GD.Progress)
-	GD.Download(fileId, cus_path, c.String("output"))
+	GD.Download(fileId, cus_path, c.String("output"), c.Int("part"))
 	return nil
 }
 
@@ -197,6 +197,11 @@ func main() {
 		&cli.StringFlag{
 			Name:  "filter",
 			Usage: "Filter files to download (e.g., 's01', 'e01', '.mp4')",
+		},
+		&cli.IntFlag{
+			Name:  "part",
+			Usage: "Number of parts for multipart downloads.",
+			Value: 1,
 		},
 	}
 	subCommandFlags := []cli.Flag{


### PR DESCRIPTION
Add support for multipart downloads with a custom number of parts and resume capability.

* **main.go**
  - Add a new flag `--part` to specify the number of parts for multipart downloads.
  - Pass the `--part` flag value to the `Download` function in `drive/drive.go`.

* **drive/drive.go**
  - Modify the `Download` function to accept the number of parts for multipart downloads.
  - Enhance the `HandleDownloadFile` function to handle multipart downloads by splitting the file into multiple parts and downloading them concurrently.
  - Implement resume capability for multipart downloads in the `HandleDownloadFile` function.
  - Add `downloadSinglePart` and `downloadMultiPart` functions to handle single-part and multi-part downloads respectively.
  - Update the `restartDownload` function to support multipart downloads.
  - Ensure MD5 checksum verification after successful download.

* **README.md**
  - Update the documentation to include information about the new `--part` flag for multipart downloads.

